### PR TITLE
Misc minor improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -21,7 +21,7 @@
         {{ range $key, $value := .Data.Terms.ByCount }}
           <tr>
             <td>
-            <a href="{{ $value.Name| urlize| relURL }}">
+            <a href="{{ $value.Name| urlize }}">
             {{ $value.Name}}
             </a>
             </td>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -32,6 +32,6 @@
     });
     </script>
     <script type="text/javascript"
-      src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+      src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
     </script>
 </footer>

--- a/layouts/partials/header.includes.html
+++ b/layouts/partials/header.includes.html
@@ -2,12 +2,12 @@
 <!-- {{ partial "highlight.html" . }} -->
 
 <!-- Pure css -->
-<link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.6.0/pure-min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pure/1.0.0/pure-min.css">
 <!--[if lte IE 8]>
-    <link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.6.0/grids-responsive-old-ie-min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pure/1.0.0/grids-responsive-old-ie-min.css">
 <![endif]-->
 <!--[if gt IE 8]><!-->
-    <link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.6.0/grids-responsive-min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pure/1.0.0/grids-responsive-min.css">
 <!--<![endif]-->
 
 <!-- Fonts -->
@@ -20,10 +20,14 @@
 
 <!-- Bootstrap stuff -->
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<script
+			  src="https://code.jquery.com/jquery-3.2.1.min.js"
+			  integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4="
+			  crossorigin="anonymous"></script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
 <!-- Main CSS file based on Pure blog layout -->
-<link rel="stylesheet" href="{{ "/css/tuftesque.css" | absURL }}">
+<link rel="stylesheet" href="{{ "css/tuftesque.css" | relURL }}">
 {{ partial "backgroundColor.html" . }}
 
 

--- a/layouts/partials/math.html
+++ b/layouts/partials/math.html
@@ -14,5 +14,5 @@ MathJax.Hub.Config({
 </script>
 
 <script type="text/javascript"
-  src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js?config=TeX-AMS_CHTML">
 </script>

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -1,7 +1,7 @@
 <meta http-equiv="content-type" content="text/html; charset=utf-8">
 <!-- Enable responsiveness on mobile devices-->
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="description" content="{{ .Description }}">
+<meta name="description" content="{{ .Description | default .Site.Params.Description }}">
 <meta name="keywords" content="{{ range .Keywords }}{{ . }},{{ end }}">
 <meta name="author" content="{{ .Site.Title }}">
 {{ .Hugo.Generator }}

--- a/tuftesque.Rproj
+++ b/tuftesque.Rproj
@@ -1,0 +1,13 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: knitr
+LaTeX: pdfLaTeX


### PR DESCRIPTION
* `.gitignore`:  Sorry, that should not be part of the request (can't figure out how to separate it).
* `layouts/_default/terms.html`:   fixes hrefs for specific tags (or categories, or whatever taxonomy) listed in `site.com/thatTaxonomy`.
*  `layouts/partials/footer.html` The Mathjax CDN is being closed down.  Unfortunately the new CDN  does not alllow for a "latest" specification, so I just inserted 2.7.2, the current Mathjax version.  (But perhaps instead we should have {{ partial "math.html" }} ?)
* ` layouts/partials/header.includes.html`:  yui.yahooapis no longer has a certificate, so some browsers won't load it under some conditions.  Here I suggest current CDNs for the Pure CSS.  Also is Bootstrap js on the list to load, and this requires JQuery.  (Should we consider moving to Bootstrap 4?)  The current tuftesque.css link works fine, but I'm just going along with the relative URL approach.
* `layouts/partials/math.html` Updating to a current CDN, see above.
* ` layouts/partials/meta.html` Increases flexibility.
*  `tuftesque.Rproj` Ignore this, sorry.